### PR TITLE
Creating Actions that arent assigned to a page automatically.

### DIFF
--- a/src/main/java/org/moon/figura/lua/api/action_wheel/ActionWheelAPI.java
+++ b/src/main/java/org/moon/figura/lua/api/action_wheel/ActionWheelAPI.java
@@ -72,6 +72,12 @@ public class ActionWheelAPI {
     }
 
     @LuaWhitelist
+    @LuaMethodDoc("action_wheel.create_action")
+    public Action createAction() {
+        return new Action();
+    }
+
+    @LuaWhitelist
     @LuaMethodDoc(
             overloads = {
                     @LuaMethodOverload,

--- a/src/main/resources/assets/figura/lang/en_us.json
+++ b/src/main/resources/assets/figura/lang/en_us.json
@@ -501,6 +501,7 @@
   "figura.docs.action_wheel.execute": "Executes the action of the given index. If the index is null, it will execute the last selected action. A second parameter can be given to specify if it should be executed the left or right action.",
   "figura.docs.action_wheel.is_enabled": "Returns if the Action Wheel is being currently rendered or not.",
   "figura.docs.action_wheel.get_selected": "Returns the index of the currently selected action.",
+  "figura.docs.action_wheel.create_action": "Creates a new Action that is not automatically asigned to a Page.",
   "figura.docs.action_wheel.create_page": "Creates a new Page for the action wheel. A Title can be given to store this page internally. If no Title is given, the Page will just be returned from this function.",
   "figura.docs.action_wheel.set_page": "Sets the Page of the action wheel to the given Title or Page.",
   "figura.docs.action_wheel.get_page": "Returns an stored Page by the given title.",


### PR DESCRIPTION
I know you denied it when it was a feature request, but its killing me that I have to do
```
  local dummyPage=action_wheel.createPage()
  dummyPage:newAction(1):title('1'),
  dummyPage:newAction(1):title('2'),
  dummyPage:newAction(1):title('3'),
  dummyPage:newAction(1):title('4'),
  dummyPage:newAction(1):title('5'),
  dummyPage:newAction(1):title('6'),
  dummyPage:newAction(1):title('7'),
  dummyPage:newAction(1):title('8'),
```
if I want many unlinked pages.