### PR TITLE
`require` function can now handle returning varargs

### DIFF
--- a/src/main/java/org/moon/figura/lua/FiguraLuaRuntime.java
+++ b/src/main/java/org/moon/figura/lua/FiguraLuaRuntime.java
@@ -132,7 +132,7 @@ public class FiguraLuaRuntime {
     private final VarArgFunction requireFunction = new VarArgFunction() {
         @Override
         public Varargs invoke(Varargs arg) {
-            String name = arg.arg1().checkjstring().replaceAll("[/\\\\]", ".");
+            String name = arg.checkjstring(1).replaceAll("[/\\\\]", ".");
             if (loadingScripts.contains(name))
                 throw new LuaError("Detected circular dependency in script " + loadingScripts.peek());
 

--- a/src/main/java/org/moon/figura/lua/FiguraLuaRuntime.java
+++ b/src/main/java/org/moon/figura/lua/FiguraLuaRuntime.java
@@ -53,7 +53,7 @@ public class FiguraLuaRuntime {
     private final Globals userGlobals = new Globals();
     private final LuaValue setHookFunction;
     protected final Map<String, String> scripts = new HashMap<>();
-    private final Map<String, LuaValue> loadedScripts = new HashMap<>();
+    private final Map<String, Varargs> loadedScripts = new HashMap<>();
     private final Stack<String> loadingScripts = new Stack<>();
     public final LuaTypeManager typeManager = new LuaTypeManager();
 
@@ -129,10 +129,10 @@ public class FiguraLuaRuntime {
         LuaString.s_metatable = new ReadOnlyLuaTable(LuaString.s_metatable);
     }
 
-    private final OneArgFunction requireFunction = new OneArgFunction() {
+    private final VarArgFunction requireFunction = new VarArgFunction() {
         @Override
-        public LuaValue call(LuaValue arg) {
-            String name = arg.checkjstring().replaceAll("[/\\\\]", ".");
+        public Varargs invoke(Varargs arg) {
+            String name = arg.arg1().checkjstring().replaceAll("[/\\\\]", ".");
             if (loadingScripts.contains(name))
                 throw new LuaError("Detected circular dependency in script " + loadingScripts.peek());
 
@@ -229,12 +229,12 @@ public class FiguraLuaRuntime {
 
     // init event //
 
-    private final Function<String, LuaValue> INIT_SCRIPT = str -> {
+    private final Function<String, Varargs> INIT_SCRIPT = str -> {
         //format name
         String name = str.replaceAll("[/\\\\]", ".");
 
         //already loaded
-        LuaValue val = loadedScripts.get(name);
+        Varargs val = loadedScripts.get(name);
         if (val != null)
             return val;
 
@@ -246,7 +246,7 @@ public class FiguraLuaRuntime {
         this.loadingScripts.push(name);
 
         //load
-        LuaValue value = userGlobals.load(src, name).call(name);
+        Varargs value = userGlobals.load(src, name).invoke(LuaValue.valueOf(name));
         if (value == LuaValue.NIL)
             value = LuaValue.TRUE;
 


### PR DESCRIPTION
I came across this when testing another commit. This feels like a mishap of using `call` instead of `invoke`, of which only `invoke` allows for more than one return, but this could perhaps be a design decision that I'm not aware of. Eh, here's a pull request for it anyways.