### PR TITLE
Added Optifine/Optifabric Compatibility

### DIFF
--- a/src/main/java/org/moon/figura/mixin/particle/ParticleEngineMixin.java
+++ b/src/main/java/org/moon/figura/mixin/particle/ParticleEngineMixin.java
@@ -10,6 +10,7 @@ import org.moon.figura.ducks.ParticleEngineAccessor;
 import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
@@ -26,9 +27,10 @@ public abstract class ParticleEngineMixin implements ParticleEngineAccessor {
 
     @Unique private final HashMap<Particle, UUID> particleMap = new HashMap<>();
 
-    @Inject(at = @At(value = "INVOKE", target = "Ljava/util/Iterator;remove()V"), method = "tickParticleList", locals = LocalCapture.CAPTURE_FAILSOFT)
-    private void tickParticleList(Collection<Particle> particles, CallbackInfo ci, Iterator<Particle> iterator, Particle particle) {
+    @ModifyVariable(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/particle/ParticleEngine;tickParticle(Lnet/minecraft/client/particle/Particle;)V"), method = "tickParticleList", ordinal = 0)
+    private Particle tickParticleList(Particle particle) {
         particleMap.remove(particle);
+        return particle;
     }
 
     @Override @Intrinsic

--- a/src/main/java/org/moon/figura/mixin/render/GameRendererMixin.java
+++ b/src/main/java/org/moon/figura/mixin/render/GameRendererMixin.java
@@ -100,8 +100,23 @@ public abstract class GameRendererMixin implements GameRendererAccessor {
             slice = @Slice(
                     from = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/vertex/PoseStack;pushPose()V"),
                     to = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/vertex/PoseStack;popPose()V")
-            ))
+            ), require = 0)
     private void preRenderItemInHand(PoseStack matrices, Camera camera, float tickDelta, CallbackInfo ci) {
+        preRenderFiguraItemInHand(matrices, camera, tickDelta);
+    }
+
+    //Injects into Optifine's renderHand method.
+    @Inject(method = "renderHand", remap = false, at = @At(value = "INVOKE", target = "Lnet/minecraft/client/Options;getCameraType()Lnet/minecraft/client/CameraType;", shift = At.Shift.BEFORE),
+            slice = @Slice(
+                    from = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/vertex/PoseStack;pushPose()V"),
+                    to = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/vertex/PoseStack;popPose()V")
+            ), require = 0)
+    public void preRenderItemInHand(PoseStack matrices, Camera camera, float tickDelta, boolean renderItem, boolean renderOverlay, boolean renderTranslucent, CallbackInfo ci) {
+        preRenderFiguraItemInHand(matrices, camera, tickDelta);
+    }
+
+    @Unique
+    private void preRenderFiguraItemInHand(PoseStack matrices, Camera camera, float tickDelta) {
         if (this.minecraft.player == null || !this.minecraft.options.getCameraType().isFirstPerson()) {
             avatar = null;
             return;
@@ -118,8 +133,19 @@ public abstract class GameRendererMixin implements GameRendererAccessor {
         }
     }
 
-    @Inject(method = "renderItemInHand", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/vertex/PoseStack;popPose()V", shift = At.Shift.BEFORE))
+    @Inject(method = "renderItemInHand", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/vertex/PoseStack;popPose()V", shift = At.Shift.BEFORE), require = 0)
     private void posRenderItemInHand(PoseStack matrices, Camera camera, float tickDelta, CallbackInfo ci) {
+        posRenderFiguraItemInHand(matrices, camera, tickDelta);
+    }
+
+    //This injects into Optifine's renderHand method.
+    @Inject(method = "renderHand", at = @At(value = "INVOKE", target = "Lcom/mojang/blaze3d/vertex/PoseStack;popPose()V", shift = At.Shift.BEFORE), require = 0)
+    private void posRenderItemInHand(PoseStack matrices, Camera camera, float tickDelta, boolean renderItem, boolean renderOverlay, boolean renderTranslucent, CallbackInfo ci) {
+        posRenderFiguraItemInHand(matrices, camera, tickDelta);
+    }
+
+    @Unique
+    private void posRenderFiguraItemInHand(PoseStack matrices, Camera camera, float tickDelta) {
         if (avatar != null) {
             FiguraMod.pushProfiler(FiguraMod.MOD_ID);
             FiguraMod.pushProfiler(avatar);

--- a/src/main/java/org/moon/figura/mixin/render/renderers/BlockEntityWithoutLevelRendererMixin.java
+++ b/src/main/java/org/moon/figura/mixin/render/renderers/BlockEntityWithoutLevelRendererMixin.java
@@ -3,6 +3,7 @@ package org.moon.figura.mixin.render.renderers;
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
 import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.block.model.ItemTransforms;
 import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
 import org.moon.figura.ducks.SkullBlockRendererAccessor;
@@ -14,8 +15,14 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 @Mixin(BlockEntityWithoutLevelRenderer.class)
 public class BlockEntityWithoutLevelRendererMixin {
 
-    @Inject(method = "renderByItem", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/blockentity/SkullBlockRenderer;renderSkull(Lnet/minecraft/core/Direction;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/client/model/SkullModelBase;Lnet/minecraft/client/renderer/RenderType;)V"))
+    @Inject(method = "renderByItem", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/blockentity/SkullBlockRenderer;renderSkull(Lnet/minecraft/core/Direction;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/client/model/SkullModelBase;Lnet/minecraft/client/renderer/RenderType;)V"), require = 0)
     void setTargetItem(ItemStack stack, ItemDisplayContext itemDisplayContext, PoseStack matrices, MultiBufferSource vertexConsumers, int light, int overlay, CallbackInfo ci) {
+        SkullBlockRendererAccessor.setItem(stack);
+    }
+
+    //Inject into Optifine's renderRaw method
+    @Inject(method = "renderRaw", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/blockentity/SkullBlockRenderer;renderSkull(Lnet/minecraft/core/Direction;FFLcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;ILnet/minecraft/client/model/SkullModelBase;Lnet/minecraft/client/renderer/RenderType;)V"), remap = false, require = 0)
+    void setTargetItem(ItemStack stack, PoseStack matrixStackIn, MultiBufferSource bufferIn, int combinedLightIn, int combinedOverlayIn, CallbackInfo ci) {
         SkullBlockRendererAccessor.setItem(stack);
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -43,8 +43,6 @@
     "canvas": "*"
   },
   "breaks": {
-    "optifine": "*",
-    "optifabric": "*"
   },
   "custom": {
     "assets_version": "${assets_version}",


### PR DESCRIPTION
Changes:
- Improvements to the ParticleEngineMixin, now uses @ModifyVariable and does not Capture Locals, this is more stable and works with Optifine
- Separated Post and Pre Render Hand methods into helper methods, added an additional inject into Optifine's renderHand method
- Added an additional inject in Inject into Optifine's (renderRaw) to set the SkullBlockItem
- Removed breaks from the fabric.mod.json.  

Those are all the changes that are required to make Figura work with Optifabric!