### PR TITLE
Minor optimization when pinging matrices

### DIFF
--- a/src/main/java/org/moon/figura/lua/api/ping/PingArg.java
+++ b/src/main/java/org/moon/figura/lua/api/ping/PingArg.java
@@ -121,11 +121,13 @@ public class PingArg {
     }
 
     private static void writeMat(FiguraMatrix<?, ?> matrix, DataOutputStream dos) throws IOException {
-        dos.writeByte(matrix.cols());
+        dos.writeByte(matrix.cols()); //this assumes matrices will always be an x by x
 
         for (int i = 0; i < matrix.cols(); i++) {
             FiguraVector<?, ?> vec = matrix.getColumn(i + 1);
-            writeVec(vec, dos);
+            for (int o=0;o<matrix.rows();o++){
+                dos.writeDouble(vec.index(o));
+            }
         }
     }
 
@@ -193,11 +195,15 @@ public class PingArg {
     }
 
     private static FiguraMatrix<?, ?> readMat(DataInputStream dis) throws IOException {
-        byte columns = dis.readByte();
+        byte size = dis.readByte();
 
-        FiguraVector<?, ?>[] vectors = new FiguraVector[columns];
-        for (int i = 0; i < columns; i++)
-            vectors[i] = readVec(dis);
+        FiguraVector<?, ?>[] vectors = new FiguraVector[size];
+        for (int i = 0; i < size; i++){
+            double[] array = new double[size];
+            for (int o = 0; o < size; o++)
+                array[o] = dis.readDouble();
+            vectors[i] = MathUtils.sizedVector(array);
+        }
 
         return MathUtils.sizedMat(vectors);
     }

--- a/src/main/java/org/moon/figura/lua/api/ping/PingArg.java
+++ b/src/main/java/org/moon/figura/lua/api/ping/PingArg.java
@@ -121,11 +121,11 @@ public class PingArg {
     }
 
     private static void writeMat(FiguraMatrix<?, ?> matrix, DataOutputStream dos) throws IOException {
-        dos.writeByte(matrix.cols()); //this assumes matrices will always be an x by x
+        dos.writeByte(matrix.cols());
 
         for (int i = 0; i < matrix.cols(); i++) {
             FiguraVector<?, ?> vec = matrix.getColumn(i + 1);
-            for (int o=0;o<matrix.rows();o++){
+            for (int o = 0; o < matrix.cols(); o++){
                 dos.writeDouble(vec.index(o));
             }
         }

--- a/src/main/java/org/moon/figura/lua/api/ping/PingArg.java
+++ b/src/main/java/org/moon/figura/lua/api/ping/PingArg.java
@@ -122,10 +122,11 @@ public class PingArg {
 
     private static void writeMat(FiguraMatrix<?, ?> matrix, DataOutputStream dos) throws IOException {
         dos.writeByte(matrix.cols());
+        dos.writeByte(matrix.rows());
 
         for (int i = 0; i < matrix.cols(); i++) {
             FiguraVector<?, ?> vec = matrix.getColumn(i + 1);
-            for (int o = 0; o < matrix.cols(); o++){
+            for (int o = 0; o < matrix.rows(); o++){
                 dos.writeDouble(vec.index(o));
             }
         }
@@ -195,12 +196,13 @@ public class PingArg {
     }
 
     private static FiguraMatrix<?, ?> readMat(DataInputStream dis) throws IOException {
-        byte size = dis.readByte();
+        byte cols = dis.readByte();
+        byte rows = dis.readByte();
 
-        FiguraVector<?, ?>[] vectors = new FiguraVector[size];
-        for (int i = 0; i < size; i++){
-            double[] array = new double[size];
-            for (int o = 0; o < size; o++)
+        FiguraVector<?, ?>[] vectors = new FiguraVector[cols];
+        for (int i = 0; i < cols; i++){
+            double[] array = new double[rows];
+            for (int o = 0; o < rows; o++)
                 array[o] = dis.readDouble();
             vectors[i] = MathUtils.sizedVector(array);
         }


### PR DESCRIPTION
The row number of the matrix is only encoded once, rather than once per vector. Raw doubles are used instead of vectors.
Figura never uses weirdly shaped matrices, so an additional byte can be saved by removing the row number, but I kept it for future proofing.

This saves like 3 bytes for a single mat4. 
Why did I bother? The repeated data irritated me. Nothing more.