### PR TITLE
Sneaky avatars (they hide in boxes!)

### DIFF
--- a/src/main/java/org/moon/figura/avatar/local/LocalAvatarFetcher.java
+++ b/src/main/java/org/moon/figura/avatar/local/LocalAvatarFetcher.java
@@ -317,7 +317,7 @@ public class LocalAvatarFetcher {
                         children.add(folder);
                         found = true;
                     }
-                } else if ("file".equalsIgnoreCase(fileSystem.provider().getScheme()) && IOUtils.getFileNameOrEmpty(path).endsWith(".zip")) {
+                } else if (IOUtils.getFileNameOrEmpty(path).endsWith(".zip")) {
                     try {
                         FileSystem opened = FileSystems.newFileSystem(path);
                         if ("jar".equalsIgnoreCase(opened.provider().getScheme())){

--- a/src/main/java/org/moon/figura/avatar/local/LocalAvatarFetcher.java
+++ b/src/main/java/org/moon/figura/avatar/local/LocalAvatarFetcher.java
@@ -43,7 +43,7 @@ public class LocalAvatarFetcher {
         ALL_AVATARS.clear();
 
         //load avatars
-        FolderPath root = new FolderPath(getLocalAvatarDirectory(), getLocalAvatarDirectory());
+        FolderPath root = new FolderPath(getLocalAvatarDirectory());
         root.fetch();
 
         //add new avatars
@@ -239,6 +239,12 @@ public class LocalAvatarFetcher {
             return folder;
         }
 
+        public Path getFSPath() {
+            Path path = getPath();
+            Path folder = getFolder();
+            return path.getFileSystem() == folder.getFileSystem() ? path : folder;
+        }
+
         public String getName() {
             return name;
         }
@@ -295,6 +301,10 @@ public class LocalAvatarFetcher {
         public FolderPath(Path path, Path folder) {
             super(path, folder);
             this.fileSystem = path.getFileSystem();
+        }
+
+        public FolderPath(Path path) {
+            this(path, path);
         }
 
         /**

--- a/src/main/java/org/moon/figura/avatar/local/LocalAvatarLoader.java
+++ b/src/main/java/org/moon/figura/avatar/local/LocalAvatarLoader.java
@@ -19,9 +19,6 @@ import org.moon.figura.utils.FiguraResourceListener;
 import org.moon.figura.utils.FiguraText;
 import org.moon.figura.utils.IOUtils;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.*;
 import java.text.SimpleDateFormat;
@@ -35,7 +32,7 @@ import java.util.regex.Pattern;
 
 /**
  * class used to load avatars from a file
- * and used for hotswapping
+ * and used for hot-swapping
  */
 public class LocalAvatarLoader {
 
@@ -118,7 +115,7 @@ public class LocalAvatarLoader {
                 loadState++;
                 if (path.toString().endsWith(".moon")) {
                     //NbtIo already closes the file stream
-                    target.loadAvatar(NbtIo.readCompressed(new FileInputStream(path.toFile())));
+                    target.loadAvatar(NbtIo.readCompressed(Files.newInputStream(path)));
                     return;
                 }
 
@@ -139,13 +136,13 @@ public class LocalAvatarLoader {
                 BlockbenchModelParser modelParser = new BlockbenchModelParser();
 
                 loadState++;
-                CompoundTag models = loadModels(path.toFile().getCanonicalPath(), path, modelParser, textures, animations, "");
+                CompoundTag models = loadModels(path.getFileSystem() == FileSystems.getDefault() ? path.toFile().getCanonicalPath() : path.toString(), path, modelParser, textures, animations, "");
                 models.putString("name", "models");
 
                 //metadata
                 loadState++;
-                String metadata = IOUtils.readFile(path.resolve("avatar.json").toFile());
-                nbt.put("metadata", AvatarMetadataParser.parse(metadata, path.getFileName().toString()));
+                String metadata = IOUtils.readFile(path.resolve("avatar.json"));
+                nbt.put("metadata", AvatarMetadataParser.parse(metadata, IOUtils.getFileNameOrEmpty(path)));
                 AvatarMetadataParser.injectToModels(metadata, models);
                 AvatarMetadataParser.injectToTextures(metadata, textures);
 
@@ -168,12 +165,12 @@ public class LocalAvatarLoader {
     }
 
     private static void loadScripts(Path path, CompoundTag nbt) throws IOException {
-        List<File> scripts = IOUtils.getFilesByExtension(path, ".lua");
+        List<Path> scripts = IOUtils.getFilesByExtension(path, ".lua");
         if (scripts.size() > 0) {
             CompoundTag scriptsNbt = new CompoundTag();
-            String pathRegex = Pattern.quote(path + File.separator);
-            for (File script : scripts) {
-                String name = script.toPath().toString()
+            String pathRegex = path.toString().isEmpty() ? "\\Q\\E" : Pattern.quote(path + path.getFileSystem().getSeparator());
+            for (Path script : scripts) {
+                String name = script.toString()
                         .replaceFirst(pathRegex, "")
                         .replaceAll("[/\\\\]", ".");
                 name = name.substring(0, name.length() - 4);
@@ -184,12 +181,12 @@ public class LocalAvatarLoader {
     }
 
     private static void loadSounds(Path path, CompoundTag nbt) throws IOException {
-        List<File> sounds = IOUtils.getFilesByExtension(path, ".ogg");
+        List<Path> sounds = IOUtils.getFilesByExtension(path, ".ogg");
         if (sounds.size() > 0) {
             CompoundTag soundsNbt = new CompoundTag();
-            String pathRegex = Pattern.quote(path + File.separator);
-            for (File sound : sounds) {
-                String name = sound.toPath().toString()
+            String pathRegex = Pattern.quote(path.toString().isEmpty() ? path.toString() : path + path.getFileSystem().getSeparator());
+            for (Path sound : sounds) {
+                String name = sound.toString()
                         .replaceFirst(pathRegex, "")
                         .replaceAll("[/\\\\]", ".");
                 name = name.substring(0, name.length() - 4);
@@ -201,13 +198,15 @@ public class LocalAvatarLoader {
 
     private static CompoundTag loadModels(String avatarFolder, Path currentFile, BlockbenchModelParser parser, CompoundTag textures, ListTag animations, String folders) throws Exception {
         CompoundTag result = new CompoundTag();
-        File[] subFiles = currentFile.toFile().listFiles(f -> !f.isHidden() && !f.getName().startsWith("."));
+        List<Path> subFiles = IOUtils.listPaths(currentFile);
         ListTag children = new ListTag();
         if (subFiles != null)
-            for (File file : subFiles) {
-                String name = file.getName();
-                if (file.isDirectory()) {
-                    CompoundTag subfolder = loadModels(avatarFolder, file.toPath(), parser, textures, animations, folders + name + ".");
+            for (Path file : subFiles) {
+                if (IOUtils.isHidden(file))
+                    continue;
+                String name = IOUtils.getFileNameOrEmpty(file);
+                if (Files.isDirectory(file)) {
+                    CompoundTag subfolder = loadModels(avatarFolder, file, parser, textures, animations, folders + name + ".");
                     if (!subfolder.isEmpty()) {
                         subfolder.putString("name", name);
                         BlockbenchModelParser.parseParent(name, subfolder);
@@ -246,9 +245,9 @@ public class LocalAvatarLoader {
         Path file = directory.resolve("cache-" + new SimpleDateFormat("yyyy_MM_dd-HH_mm_ss").format(new Date()) + ".moon");
         try {
             IOUtils.createDirIfNeeded(directory);
-            NbtIo.writeCompressed(nbt, new FileOutputStream(file.toFile()));
+            NbtIo.writeCompressed(nbt, Files.newOutputStream(file));
         } catch (Exception e) {
-            FiguraMod.LOGGER.error("Failed to save avatar: " + file.getFileName().toString(), e);
+            FiguraMod.LOGGER.error("Failed to save avatar: " + IOUtils.getFileNameOrEmpty(file), e);
         }
     }
 
@@ -270,14 +269,14 @@ public class LocalAvatarLoader {
                     continue;
 
                 event = watchEvent;
-                File file = entry.getKey().resolve(((WatchEvent<Path>) event).context()).toFile();
-                String name = file.getName();
+                Path path = entry.getKey().resolve((Path) event.context());
+                String name = IOUtils.getFileNameOrEmpty(path);
 
-                if (file.isHidden() || name.startsWith(".") || (!file.isDirectory() && !name.matches("(.*(\\.lua|\\.bbmodel|\\.ogg|\\.png)$|avatar\\.json)")))
+                if (IOUtils.isHidden(path) || !(Files.isDirectory(path) || name.matches("(.*(\\.lua|\\.bbmodel|\\.ogg|\\.png)$|avatar\\.json)")))
                     continue;
 
                 if (kind == StandardWatchEventKinds.ENTRY_CREATE && !IS_WINDOWS)
-                    addWatchKey(file.toPath(), KEYS::put);
+                    addWatchKey(path, KEYS::put);
 
                 reload = true;
                 break;
@@ -308,11 +307,10 @@ public class LocalAvatarLoader {
      * @param consumer a consumer that will process the watch key and its path
      */
     protected static void addWatchKey(Path path, BiConsumer<Path, WatchKey> consumer) {
-        if (watcher == null || path == null)
+        if (watcher == null || path == null || path.getFileSystem() != FileSystems.getDefault())
             return;
 
-        File file = path.toFile();
-        if (!file.isDirectory() || file.isHidden() || file.getName().startsWith("."))
+        if (!Files.isDirectory(path) || IOUtils.isHidden(path))
             return;
 
         try {
@@ -321,12 +319,12 @@ public class LocalAvatarLoader {
 
             consumer.accept(path, key);
 
-            File[] children = file.listFiles();
+            List<Path> children = IOUtils.listPaths(path);
             if (children == null || IS_WINDOWS)
                 return;
 
-            for (File child : children)
-                addWatchKey(child.toPath(), consumer);
+            for (Path child : children)
+                addWatchKey(child, consumer);
         } catch (Exception e) {
             FiguraMod.LOGGER.error("Failed to register watcher for " + path, e);
         }

--- a/src/main/java/org/moon/figura/commands/FiguraDebugCommand.java
+++ b/src/main/java/org/moon/figura/commands/FiguraDebugCommand.java
@@ -29,12 +29,13 @@ import org.moon.figura.permissions.PermissionPack;
 import org.moon.figura.permissions.Permissions;
 import org.moon.figura.resources.FiguraRuntimeResources;
 import org.moon.figura.utils.FiguraText;
+import org.moon.figura.utils.IOUtils;
 import org.moon.figura.utils.MathUtils;
 
 import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
-import java.io.FileOutputStream;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -64,7 +65,7 @@ public class FiguraDebugCommand {
                 Files.createFile(targetPath);
 
             //write file
-            FileOutputStream fs = new FileOutputStream(targetPath.toFile());
+            OutputStream fs = Files.newOutputStream(targetPath);
             fs.write(fetchStatus(AvatarManager.getAvatarForPlayer(FiguraMod.getLocalPlayerUUID())).getBytes());
             fs.close();
 
@@ -73,7 +74,7 @@ public class FiguraDebugCommand {
                     FiguraText.of("command.debug.success")
                             .append(" ")
                             .append(FiguraText.of("command.click_to_open")
-                                    .setStyle(Style.EMPTY.withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_FILE, targetPath.toFile().toString())).withUnderlined(true))
+                                    .setStyle(Style.EMPTY.withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_FILE, targetPath.toString())).withUnderlined(true))
                             )
             );
             return 1;
@@ -253,7 +254,7 @@ public class FiguraDebugCommand {
         JsonObject avatar = new JsonObject();
 
         for (LocalAvatarFetcher.AvatarPath path : list) {
-            String name = path.getPath().getFileName().toString();
+            String name = IOUtils.getFileNameOrEmpty(path.getPath());
 
             if (path instanceof LocalAvatarFetcher.FolderPath folder)
                 avatar.add(name, getAvatarsPaths(folder.getChildren()));

--- a/src/main/java/org/moon/figura/config/InputType.java
+++ b/src/main/java/org/moon/figura/config/InputType.java
@@ -4,6 +4,7 @@ import net.minecraft.client.multiplayer.resolver.ServerAddress;
 import org.moon.figura.gui.widgets.TextField;
 import org.moon.figura.utils.ColorUtils;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.function.Predicate;
 
@@ -44,7 +45,7 @@ public enum InputType {
     HEX_COLOR(s -> ColorUtils.userInputHex(s, null) != null),
     FOLDER_PATH(s -> {
         try {
-            return s.isBlank() || Path.of(s.trim()).toFile().isDirectory();
+            return s.isBlank() || Files.isDirectory(Path.of(s.trim()));
         } catch (Exception ignored) {
             return false;
         }

--- a/src/main/java/org/moon/figura/gui/screens/WardrobeScreen.java
+++ b/src/main/java/org/moon/figura/gui/screens/WardrobeScreen.java
@@ -20,6 +20,7 @@ import org.moon.figura.gui.widgets.*;
 import org.moon.figura.gui.widgets.lists.AvatarList;
 import org.moon.figura.utils.FiguraIdentifier;
 import org.moon.figura.utils.FiguraText;
+import org.moon.figura.utils.IOUtils;
 import org.moon.figura.utils.TextUtils;
 import org.moon.figura.utils.ui.UIHelper;
 
@@ -206,7 +207,7 @@ public class WardrobeScreen extends AbstractPanelScreen {
         for (int i = 0; i < paths.size(); i++) {
             if (i > 0)
                 packs.append("\n");
-            packs.append(paths.get(i).getFileName());
+            packs.append(IOUtils.getFileNameOrEmpty(paths.get(i)));
         }
 
         this.minecraft.setScreen(new FiguraConfirmScreen(confirmed -> {

--- a/src/main/java/org/moon/figura/gui/widgets/avatar/AbstractAvatarWidget.java
+++ b/src/main/java/org/moon/figura/gui/widgets/avatar/AbstractAvatarWidget.java
@@ -7,16 +7,18 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.Style;
+import org.jetbrains.annotations.NotNull;
 import org.moon.figura.avatar.local.LocalAvatarFetcher;
 import org.moon.figura.gui.FiguraToast;
 import org.moon.figura.gui.widgets.AbstractContainerElement;
-import org.moon.figura.gui.widgets.ContextMenu;
 import org.moon.figura.gui.widgets.Button;
+import org.moon.figura.gui.widgets.ContextMenu;
 import org.moon.figura.gui.widgets.lists.AvatarList;
 import org.moon.figura.utils.FiguraText;
 import org.moon.figura.utils.ui.UIHelper;
 
-import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 public abstract class AbstractAvatarWidget extends AbstractContainerElement implements Comparable<AbstractAvatarWidget> {
 
@@ -49,8 +51,8 @@ public abstract class AbstractAvatarWidget extends AbstractContainerElement impl
             context.updateDimensions();
         });
         context.addAction(FiguraText.of("gui.context.open_folder"), null, button -> {
-            File f = avatar.getPath().toFile();
-            Util.getPlatform().openFile(f.isDirectory() ? f : f.getParentFile());
+            Path path = avatar.getPath();
+            Util.getPlatform().openUri(Files.isDirectory(path) ? path.toUri() : path.getParent().toUri());
         });
         context.addAction(FiguraText.of("gui.context.copy_path"), null, button -> {
             Minecraft.getInstance().keyboardHandler.setClipboard(avatar.getPath().toString());
@@ -138,7 +140,7 @@ public abstract class AbstractAvatarWidget extends AbstractContainerElement impl
     }
 
     @Override
-    public int compareTo(AbstractAvatarWidget other) {
+    public int compareTo(@NotNull AbstractAvatarWidget other) {
         //compare favourite
         if (this.favourite && !other.favourite)
             return -1;

--- a/src/main/java/org/moon/figura/gui/widgets/avatar/AbstractAvatarWidget.java
+++ b/src/main/java/org/moon/figura/gui/widgets/avatar/AbstractAvatarWidget.java
@@ -18,8 +18,6 @@ import org.moon.figura.gui.widgets.lists.AvatarList;
 import org.moon.figura.utils.FiguraText;
 import org.moon.figura.utils.ui.UIHelper;
 
-import java.nio.file.Path;
-
 public abstract class AbstractAvatarWidget extends AbstractContainerElement implements Comparable<AbstractAvatarWidget> {
 
     protected static final int SPACING = 6;
@@ -52,15 +50,14 @@ public abstract class AbstractAvatarWidget extends AbstractContainerElement impl
         });
         context.addAction(FiguraText.of("gui.context.open_folder"), null, button -> {
             try {
-                Path folder = avatar.getPath().getFileSystem() == avatar.getFolder().getFileSystem() ? avatar.getPath() : avatar.getFolder();
-                Util.getPlatform().openUri(folder.toUri());
+                Util.getPlatform().openUri(avatar.getFSPath().toUri());
             } catch (Exception e) {
                 FiguraMod.debug("failed to open avatar folder: ", e.getMessage());
                 Util.getPlatform().openUri(LocalAvatarFetcher.getLocalAvatarDirectory().toUri());
             }
         });
         context.addAction(FiguraText.of("gui.context.copy_path"), null, button -> {
-            Minecraft.getInstance().keyboardHandler.setClipboard(avatar.getPath().toString());
+            Minecraft.getInstance().keyboardHandler.setClipboard(avatar.getFSPath().toString());
             FiguraToast.sendToast(FiguraText.of("toast.clipboard"));
         });
     }

--- a/src/main/java/org/moon/figura/gui/widgets/avatar/AbstractAvatarWidget.java
+++ b/src/main/java/org/moon/figura/gui/widgets/avatar/AbstractAvatarWidget.java
@@ -18,6 +18,8 @@ import org.moon.figura.gui.widgets.lists.AvatarList;
 import org.moon.figura.utils.FiguraText;
 import org.moon.figura.utils.ui.UIHelper;
 
+import java.nio.file.Path;
+
 public abstract class AbstractAvatarWidget extends AbstractContainerElement implements Comparable<AbstractAvatarWidget> {
 
     protected static final int SPACING = 6;
@@ -50,7 +52,8 @@ public abstract class AbstractAvatarWidget extends AbstractContainerElement impl
         });
         context.addAction(FiguraText.of("gui.context.open_folder"), null, button -> {
             try {
-                Util.getPlatform().openUri(avatar.getFolder().toUri());
+                Path folder = avatar.getPath().getFileSystem() == avatar.getFolder().getFileSystem() ? avatar.getPath() : avatar.getFolder();
+                Util.getPlatform().openUri(folder.toUri());
             } catch (Exception e) {
                 FiguraMod.debug("failed to open avatar folder: ", e.getMessage());
                 Util.getPlatform().openUri(LocalAvatarFetcher.getLocalAvatarDirectory().toUri());

--- a/src/main/java/org/moon/figura/gui/widgets/avatar/AbstractAvatarWidget.java
+++ b/src/main/java/org/moon/figura/gui/widgets/avatar/AbstractAvatarWidget.java
@@ -17,6 +17,7 @@ import org.moon.figura.gui.widgets.lists.AvatarList;
 import org.moon.figura.utils.FiguraText;
 import org.moon.figura.utils.ui.UIHelper;
 
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -52,6 +53,10 @@ public abstract class AbstractAvatarWidget extends AbstractContainerElement impl
         });
         context.addAction(FiguraText.of("gui.context.open_folder"), null, button -> {
             Path path = avatar.getPath();
+            if (path.getFileSystem() != FileSystems.getDefault()) {
+                String[] paths = path.toUri().toString().split("(?<=\\.zip)!/")[0].split("(?<=\\G[a-z]{1,}:)");
+                path = Path.of(paths[paths.length - 1]);
+            }
             Util.getPlatform().openUri(Files.isDirectory(path) ? path.toUri() : path.getParent().toUri());
         });
         context.addAction(FiguraText.of("gui.context.copy_path"), null, button -> {

--- a/src/main/java/org/moon/figura/gui/widgets/avatar/AbstractAvatarWidget.java
+++ b/src/main/java/org/moon/figura/gui/widgets/avatar/AbstractAvatarWidget.java
@@ -8,6 +8,7 @@ import net.minecraft.client.gui.Font;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.Style;
 import org.jetbrains.annotations.NotNull;
+import org.moon.figura.FiguraMod;
 import org.moon.figura.avatar.local.LocalAvatarFetcher;
 import org.moon.figura.gui.FiguraToast;
 import org.moon.figura.gui.widgets.AbstractContainerElement;
@@ -16,10 +17,6 @@ import org.moon.figura.gui.widgets.ContextMenu;
 import org.moon.figura.gui.widgets.lists.AvatarList;
 import org.moon.figura.utils.FiguraText;
 import org.moon.figura.utils.ui.UIHelper;
-
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Path;
 
 public abstract class AbstractAvatarWidget extends AbstractContainerElement implements Comparable<AbstractAvatarWidget> {
 
@@ -52,12 +49,12 @@ public abstract class AbstractAvatarWidget extends AbstractContainerElement impl
             context.updateDimensions();
         });
         context.addAction(FiguraText.of("gui.context.open_folder"), null, button -> {
-            Path path = avatar.getPath();
-            if (path.getFileSystem() != FileSystems.getDefault()) {
-                String[] paths = path.toUri().toString().split("(?<=\\.zip)!/")[0].split("(?<=\\G[a-z]{1,}:)");
-                path = Path.of(paths[paths.length - 1]);
+            try {
+                Util.getPlatform().openUri(avatar.getFolder().toUri());
+            } catch (Exception e) {
+                FiguraMod.debug("failed to open avatar folder: ", e.getMessage());
+                Util.getPlatform().openUri(LocalAvatarFetcher.getLocalAvatarDirectory().toUri());
             }
-            Util.getPlatform().openUri(Files.isDirectory(path) ? path.toUri() : path.getParent().toUri());
         });
         context.addAction(FiguraText.of("gui.context.copy_path"), null, button -> {
             Minecraft.getInstance().keyboardHandler.setClipboard(avatar.getPath().toString());

--- a/src/main/java/org/moon/figura/gui/widgets/avatar/AvatarFolderWidget.java
+++ b/src/main/java/org/moon/figura/gui/widgets/avatar/AvatarFolderWidget.java
@@ -13,7 +13,7 @@ import java.util.HashSet;
 public class AvatarFolderWidget extends AbstractAvatarWidget {
 
     private final HashMap<String, AbstractAvatarWidget> entries = new HashMap<>();
-    private final ArrayList<AbstractAvatarWidget> sortedEntires = new ArrayList<>();
+    private final ArrayList<AbstractAvatarWidget> sortedEntries = new ArrayList<>();
 
     public AvatarFolderWidget(int depth, int width, LocalAvatarFetcher.FolderPath avatar, AvatarList parent) {
         super(depth, width, 20, avatar, parent);
@@ -105,8 +105,8 @@ public class AvatarFolderWidget extends AbstractAvatarWidget {
         for (String str : missingPaths)
             children.remove(entries.remove(str));
 
-        sortedEntires.clear();
-        sortedEntires.addAll(entries.values());
+        sortedEntries.clear();
+        sortedEntries.addAll(entries.values());
 
         //sort children
         children.sort((children1, children2) -> {
@@ -114,7 +114,7 @@ public class AvatarFolderWidget extends AbstractAvatarWidget {
                 return avatar1.compareTo(avatar2);
             return 0;
         });
-        sortedEntires.sort(AbstractAvatarWidget::compareTo);
+        sortedEntries.sort(AbstractAvatarWidget::compareTo);
 
         //update height
         updateHeight();
@@ -149,7 +149,7 @@ public class AvatarFolderWidget extends AbstractAvatarWidget {
     @Override
     public void setX(int x) {
         super.setX(x);
-        for (AbstractAvatarWidget widget : sortedEntires) {
+        for (AbstractAvatarWidget widget : sortedEntries) {
             if (widget.isVisible())
                 widget.setX(x);
         }
@@ -160,7 +160,7 @@ public class AvatarFolderWidget extends AbstractAvatarWidget {
         super.setY(y);
 
         y = 22;
-        for (AbstractAvatarWidget widget : sortedEntires) {
+        for (AbstractAvatarWidget widget : sortedEntries) {
             if (widget.isVisible()) {
                 widget.setY(this.getY() + y);
                 y += widget.getHeight() + 2;

--- a/src/main/java/org/moon/figura/gui/widgets/lists/AvatarList.java
+++ b/src/main/java/org/moon/figura/gui/widgets/lists/AvatarList.java
@@ -77,7 +77,7 @@ public class AvatarList extends AbstractList {
                 new FiguraIdentifier("textures/gui/folder.png"),
                 60, 20,
                 FiguraText.of("gui.wardrobe.folder.tooltip"),
-                button -> Util.getPlatform().openFile(LocalAvatarFetcher.getLocalAvatarDirectory().toFile()))
+                button -> Util.getPlatform().openUri(LocalAvatarFetcher.getLocalAvatarDirectory().toUri()))
         );
 
         //scrollbar

--- a/src/main/java/org/moon/figura/lua/api/ConfigAPI.java
+++ b/src/main/java/org/moon/figura/lua/api/ConfigAPI.java
@@ -15,8 +15,9 @@ import org.moon.figura.math.vector.FiguraVector;
 import org.moon.figura.utils.IOUtils;
 import org.moon.figura.utils.MathUtils;
 
-import java.io.FileOutputStream;
-import java.io.FileReader;
+import java.io.BufferedReader;
+import java.io.OutputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Base64;
@@ -61,7 +62,7 @@ public class ConfigAPI {
     }
 
     public static void clearAllData() {
-        IOUtils.deleteFile(getConfigDataDir().toFile());
+        IOUtils.deleteFile(getConfigDataDir());
     }
 
     private Path getPath() {
@@ -89,7 +90,7 @@ public class ConfigAPI {
             root.add(key.toString(), writeArg(luaTable.get(key), new JsonObject()));
 
         //write file
-        try (FileOutputStream fs = new FileOutputStream(path.toFile())) {
+        try (OutputStream fs = Files.newOutputStream(path)) {
             fs.write(GSON.toJson(root).getBytes());
         } catch (Exception e) {
             FiguraMod.LOGGER.error("", e);
@@ -179,10 +180,10 @@ public class ConfigAPI {
         Path path = getPath();
         JsonObject root;
 
-        if (!path.toFile().exists())
+        if (!Files.exists(path))
             return;
 
-        try (FileReader reader = new FileReader(path.toFile())) {
+        try (BufferedReader reader = Files.newBufferedReader(path)) {
             JsonElement element = JsonParser.parseReader(reader);
             if (element.isJsonNull())
                 return;

--- a/src/main/java/org/moon/figura/lua/docs/FiguraDocsManager.java
+++ b/src/main/java/org/moon/figura/lua/docs/FiguraDocsManager.java
@@ -59,7 +59,7 @@ import org.moon.figura.model.rendering.texture.FiguraTexture;
 import org.moon.figura.model.rendertasks.*;
 import org.moon.figura.utils.FiguraText;
 
-import java.io.FileOutputStream;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
@@ -341,7 +341,7 @@ public class FiguraDocsManager {
                 Files.createFile(targetPath);
 
             //write file
-            FileOutputStream fs = new FileOutputStream(targetPath.toFile());
+            OutputStream fs = Files.newOutputStream(targetPath);
             fs.write(exportAsJsonString(translate).getBytes());
             fs.close();
 
@@ -350,7 +350,7 @@ public class FiguraDocsManager {
                     FiguraText.of("command.docs_export.success")
                             .append(" ")
                             .append(FiguraText.of("command.click_to_open")
-                                    .setStyle(Style.EMPTY.withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_FILE, targetPath.toFile().toString())).withUnderlined(true))
+                                    .setStyle(Style.EMPTY.withClickEvent(new ClickEvent(ClickEvent.Action.OPEN_FILE, targetPath.toString())).withUnderlined(true))
                             )
             );
             return 1;

--- a/src/main/java/org/moon/figura/resources/FiguraRuntimeResources.java
+++ b/src/main/java/org/moon/figura/resources/FiguraRuntimeResources.java
@@ -8,9 +8,10 @@ import org.moon.figura.FiguraMod;
 import org.moon.figura.backend2.NetworkStuff;
 import org.moon.figura.utils.IOUtils;
 
-import java.io.FileOutputStream;
-import java.io.FileReader;
+import java.io.BufferedReader;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -31,7 +32,7 @@ public class FiguraRuntimeResources {
     private static CompletableFuture<Void> future;
 
     public static void clearCache() {
-        IOUtils.deleteFile(getRootDirectory().toFile());
+        IOUtils.deleteFile(getRootDirectory());
     }
 
     public static CompletableFuture<Void> init() {
@@ -42,7 +43,7 @@ public class FiguraRuntimeResources {
 
             //get old hashes
             Path hashesPath = getRootDirectory().resolve("hashes.json");
-            try (FileReader reader = new FileReader(hashesPath.toFile())) {
+            try (BufferedReader reader = Files.newBufferedReader(hashesPath)) {
                 oldHashes = JsonParser.parseReader(reader).getAsJsonObject();
             } catch (Exception ignored) {
                 oldHashes = new JsonObject();
@@ -55,7 +56,7 @@ public class FiguraRuntimeResources {
                 hashes = JsonParser.parseString(s).getAsJsonObject();
 
                 //save new hashes
-                try (FileOutputStream fs = new FileOutputStream(hashesPath.toFile())) {
+                try (OutputStream fs = Files.newOutputStream(hashesPath)) {
                     fs.write(bytes);
                 } catch (Exception e) {
                     FiguraMod.LOGGER.error("Failed to save resource hashes", e);
@@ -83,7 +84,7 @@ public class FiguraRuntimeResources {
     private static void getAndSaveResource(String path) throws Exception {
         Path target = getAssetsDirectory().resolve(path);
         IOUtils.createDirIfNeeded(target.getParent());
-        try (InputStream resource = NetworkStuff.getResource(ASSETS_VERSION, path); FileOutputStream fs = new FileOutputStream(target.toFile())) {
+        try (InputStream resource = NetworkStuff.getResource(ASSETS_VERSION, path); OutputStream fs = Files.newOutputStream(target)) {
             fs.write(resource.readAllBytes());
             FiguraMod.debug("Downloaded resource \"" + path + "\"");
         }

--- a/src/main/java/org/moon/figura/utils/FileTexture.java
+++ b/src/main/java/org/moon/figura/utils/FileTexture.java
@@ -28,7 +28,7 @@ public class FileTexture extends DynamicTexture {
     }
 
     public static NativeImage readImage(Path path) throws IOException {
-        byte[] bytes = IOUtils.readFileBytes(path.toFile());
+        byte[] bytes = IOUtils.readFileBytes(path);
         ByteBuffer wrapper = BufferUtils.createByteBuffer(bytes.length);
 
         wrapper.put(bytes);

--- a/src/main/java/org/moon/figura/utils/IOUtils.java
+++ b/src/main/java/org/moon/figura/utils/IOUtils.java
@@ -4,41 +4,42 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtIo;
 import org.moon.figura.FiguraMod;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class IOUtils {
 
     public static final String INVALID_FILENAME_REGEX = "CON|PRN|AUX|NUL|COM\\d|LPT\\d|[\\\\/:*?\"<>|\u0000]|\\.$";
 
-    public static List<File> getFilesByExtension(Path root, String extension) {
-        List<File> result = new ArrayList<>();
-        File rf = root.toFile();
-        File[] children = rf.listFiles();
+    public static List<Path> getFilesByExtension(Path root, String extension) {
+        List<Path> result = new ArrayList<>();
+        List<Path> children = listPaths(root);
         if (children == null) return result;
-        for (File child : children) {
-            if (child.isHidden() || child.getName().startsWith("."))
+        for (Path child : children) {
+            if (IOUtils.isHidden(child))
                 continue;
 
-            if (child.isDirectory())
-                result.addAll(getFilesByExtension(child.toPath(), extension));
+            if (Files.isDirectory(child))
+                result.addAll(getFilesByExtension(child, extension));
             else if (child.toString().toLowerCase().endsWith(extension.toLowerCase()))
                 result.add(child);
         }
         return result;
     }
 
-    public static String readFile(File file) throws IOException {
-        try (FileInputStream stream = new FileInputStream(file)) {
+    public static String readFile(Path file) throws IOException {
+        try (InputStream stream = Files.newInputStream(file)) {
             return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
         } catch (IOException e) {
             FiguraMod.LOGGER.error("Failed to read File: " + file);
@@ -46,8 +47,8 @@ public class IOUtils {
         }
     }
 
-    public static byte[] readFileBytes(File file) throws IOException {
-        try (FileInputStream stream = new FileInputStream(file)) {
+    public static byte[] readFileBytes(Path file) throws IOException {
+        try (InputStream stream = Files.newInputStream(file)) {
             return stream.readAllBytes();
         } catch (IOException e) {
             FiguraMod.LOGGER.error("Failed to read File: " + file);
@@ -64,7 +65,7 @@ public class IOUtils {
                 return;
 
             //read file
-            FileInputStream fis = new FileInputStream(path.toFile());
+            InputStream fis = Files.newInputStream(path);
             CompoundTag nbt = NbtIo.readCompressed(fis);
             consumer.accept(nbt);
             fis.close();
@@ -86,7 +87,7 @@ public class IOUtils {
                 Files.createFile(path);
 
             //write file
-            FileOutputStream fs = new FileOutputStream(path.toFile());
+            OutputStream fs = Files.newOutputStream(path);
             NbtIo.writeCompressed(nbt, fs);
             fs.close();
         } catch (Exception e) {
@@ -96,7 +97,7 @@ public class IOUtils {
 
     public static void deleteCacheFile(String name) {
         Path path = FiguraMod.getCacheDirectory().resolve(name + ".nbt");
-        deleteFile(path.toFile());
+        deleteFile(path);
     }
 
     public static Path getOrCreateDir(Path startingPath, String dir) {
@@ -114,31 +115,54 @@ public class IOUtils {
         return path;
     }
 
-    public static void deleteFile(File file) {
-        if (!file.exists())
-            return;
+    public static void deleteFile(Path file) {
+        try {
+            if(!Files.exists(file))
+                return;
 
-        File[] files = file.listFiles();
-        if (files != null) {
-            for (File f : files) {
-                if (f.isDirectory()) {
-                    deleteFile(f);
-                } else {
-                    f.delete();
+            List<Path> paths = listPaths(file);
+            if (paths != null) {
+                for (Path path : paths) {
+                    deleteFile(path);
                 }
             }
+            Files.delete(file);
+        } catch (Exception e) {
+            FiguraMod.LOGGER.error("Failed to delete " + file, e);
         }
-
-        file.delete();
     }
 
     public static void writeFile(Path path, byte[] data) throws IOException {
         if (data == null)
             return;
 
-        try (FileOutputStream fs = new FileOutputStream(path.toFile())) {
+        try (OutputStream fs = Files.newOutputStream(path)) {
             fs.write(data);
         }
+    }
+
+    public static List<Path> listPaths(Path dir) {
+        try (Stream<Path> stream = Files.list(dir)) {
+            return stream.sorted(Comparator.comparing(IOUtils::getFileNameOrEmpty)).collect(Collectors.toList());
+        } catch (IOException ioe) {
+            return null;
+        }
+    }
+
+    public static String getFileNameOrEmpty(Path path) {
+        Path filename = path.getFileName();
+        return filename == null ? "" : filename.toString();
+    }
+
+    public static boolean isHidden(Path path) {
+        boolean hidden;
+        try {
+            hidden = Files.isHidden(path);
+        } catch (IOException e) {
+            FiguraMod.LOGGER.error("Failed to get if \"" + path + "\" is hidden", e);
+            hidden = false;
+        }
+        return hidden || getFileNameOrEmpty(path).startsWith(".");
     }
 
     public static class DirWrapper {

--- a/src/main/java/org/moon/figura/wizards/AvatarWizard.java
+++ b/src/main/java/org/moon/figura/wizards/AvatarWizard.java
@@ -118,7 +118,7 @@ public class AvatarWizard {
                 .write("avatar.png", iconTexture);
 
         //open file manager
-        Util.getPlatform().openFile(folder.toFile());
+        Util.getPlatform().openUri(folder.toUri());
     }
 
     private byte[] buildMetadata(String name) {


### PR DESCRIPTION
- Replaced most (if not all) of the `java.io.File`-based logic with `java.nio.file.Path + java.nio.file.Files`-based logic, allowing usage of different (from FileSystems.getDefault()) filesystems, such as zip files, should probably work with something like a ftp:// folder as well.
- Implemented loading avatars from zip folders
- Made avatar file size — filesystem enumeration order independent