### PR TITLE
Add functions for accessing slot information of the current screen

### DIFF
--- a/src/main/java/org/moon/figura/lua/api/HostAPI.java
+++ b/src/main/java/org/moon/figura/lua/api/HostAPI.java
@@ -12,10 +12,11 @@ import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.multiplayer.ClientPacketListener;
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.commands.arguments.SlotArgument;
-import net.minecraft.network.chat.Component;
+import net.minecraft.core.NonNullList;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.inventory.Slot;
 import org.luaj.vm2.LuaError;
 import org.moon.figura.FiguraMod;
 import org.moon.figura.avatar.Avatar;
@@ -431,23 +432,21 @@ public class HostAPI {
     @LuaWhitelist
     @LuaMethodDoc("host.get_screen_slot_count")
     public Integer getScreenSlotCount() {
-        if (isHost() && this.minecraft.screen instanceof AbstractContainerScreen<?> screen) {
+        if (isHost() && this.minecraft.screen instanceof AbstractContainerScreen<?> screen)
             return screen.getMenu().slots.size();
-        }
         return null;
     }
 
     @LuaWhitelist
     @LuaMethodDoc("host.get_screen_slot")
     public ItemStackAPI getScreenSlot(int index) {
-        if (isHost() && this.minecraft.screen instanceof AbstractContainerScreen<?> screen) {
-            var slots = screen.getMenu().slots;
-            if (index > slots.size()) {
-                return null;
-            }
-            return ItemStackAPI.verify(slots.get(index).getItem());
-        }
-        return null;
+        if (!isHost() || !(this.minecraft.screen instanceof AbstractContainerScreen<?> screen))
+            return null;
+
+        NonNullList<Slot> slots = screen.getMenu().slots;
+        if (index < 0 || index >= slots.size())
+            return null;
+        return ItemStackAPI.verify(slots.get(index).getItem());
     }
 
     @LuaWhitelist

--- a/src/main/java/org/moon/figura/lua/api/HostAPI.java
+++ b/src/main/java/org/moon/figura/lua/api/HostAPI.java
@@ -435,7 +435,7 @@ public class HostAPI {
     @LuaMethodDoc("host.get_screen_slot_count")
     public Integer getScreenSlotCount() {
         if (isHost() && this.minecraft.screen instanceof HandledScreen<ScreenHandler> screen) {
-            return screen.getScreenHandler().slots.size()
+            return screen.getScreenHandler().slots.size();
         }
         return null;
     }

--- a/src/main/java/org/moon/figura/lua/api/HostAPI.java
+++ b/src/main/java/org/moon/figura/lua/api/HostAPI.java
@@ -441,11 +441,11 @@ public class HostAPI {
     }
 
     @LuaWhitelist
-    @LuaMethodDoc("host.get_screen_slot_count")
-    public ItemStackAPI getScreenSlotCount(int slot) {
+    @LuaMethodDoc("host.get_screen_slot")
+    public ItemStackAPI getScreenSlot(int index) {
         if (isHost() && this.minecraft.screen instanceof HandledScreen<ScreenHandler> screen) {
             var slots = screen.getScreenHandler().slots;
-            if (slot > slots.size()) {
+            if (index > slots.size()) {
                 return null;
             }
             return ItemStackAPI.verify(slots.get(index).get());

--- a/src/main/java/org/moon/figura/lua/api/HostAPI.java
+++ b/src/main/java/org/moon/figura/lua/api/HostAPI.java
@@ -7,6 +7,9 @@ import net.minecraft.client.GuiMessage;
 import net.minecraft.client.GuiMessageTag;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.Screenshot;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.client.gui.screen.ingame.ScreenHandler;
 import net.minecraft.client.gui.screens.ChatScreen;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.multiplayer.ClientPacketListener;
@@ -426,6 +429,28 @@ public class HostAPI {
         if (!isHost() || this.minecraft.screen == null)
             return null;
         return this.minecraft.screen.getClass().getName();
+    }
+
+    @LuaWhitelist
+    @LuaMethodDoc("host.get_screen_slot_count")
+    public Integer getScreenSlotCount() {
+        if (isHost() && this.minecraft.screen instanceof HandledScreen<ScreenHandler> screen) {
+            return screen.getScreenHandler().slots.size()
+        }
+        return null;
+    }
+
+    @LuaWhitelist
+    @LuaMethodDoc("host.get_screen_slot_count")
+    public ItemStackAPI getScreenSlotCount(int slot) {
+        if (isHost() && this.minecraft.screen instanceof HandledScreen<ScreenHandler> screen) {
+            var slots = screen.getScreenHandler().slots;
+            if (slot > slots.size()) {
+                return null;
+            }
+            return ItemStackAPI.verify(slots.get(index).get());
+        }
+        return null;
     }
 
     @LuaWhitelist

--- a/src/main/java/org/moon/figura/lua/api/HostAPI.java
+++ b/src/main/java/org/moon/figura/lua/api/HostAPI.java
@@ -7,9 +7,6 @@ import net.minecraft.client.GuiMessage;
 import net.minecraft.client.GuiMessageTag;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.Screenshot;
-import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.screen.ingame.HandledScreen;
-import net.minecraft.client.gui.screen.ingame.ScreenHandler;
 import net.minecraft.client.gui.screens.ChatScreen;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.multiplayer.ClientPacketListener;
@@ -434,8 +431,8 @@ public class HostAPI {
     @LuaWhitelist
     @LuaMethodDoc("host.get_screen_slot_count")
     public Integer getScreenSlotCount() {
-        if (isHost() && this.minecraft.screen instanceof HandledScreen<ScreenHandler> screen) {
-            return screen.getScreenHandler().slots.size();
+        if (isHost() && this.minecraft.screen instanceof AbstractContainerScreen<?> screen) {
+            return screen.getMenu().slots.size();
         }
         return null;
     }
@@ -443,12 +440,12 @@ public class HostAPI {
     @LuaWhitelist
     @LuaMethodDoc("host.get_screen_slot")
     public ItemStackAPI getScreenSlot(int index) {
-        if (isHost() && this.minecraft.screen instanceof HandledScreen<ScreenHandler> screen) {
-            var slots = screen.getScreenHandler().slots;
+        if (isHost() && this.minecraft.screen instanceof AbstractContainerScreen<?> screen) {
+            var slots = screen.getMenu().slots;
             if (index > slots.size()) {
                 return null;
             }
-            return ItemStackAPI.verify(slots.get(index).get());
+            return ItemStackAPI.verify(slots.get(index).getItem());
         }
         return null;
     }

--- a/src/main/resources/assets/figura/lang/en_us.json
+++ b/src/main/resources/assets/figura/lang/en_us.json
@@ -1126,6 +1126,8 @@
   "figura.docs.host.get_chat_text": "Gets the text that is currently being typed into the chat window",
   "figura.docs.host.set_chat_text": "Sets the text currently being typed in the chat window to the given string",
   "figura.docs.host.get_screen": "Gets the class name of the screen the player is currently on\nIf the player is not currently in a screen, returns nil",
+  "figura.docs.host.get_screen_slot_count": "Gets the number of slots in the screen the player is currently in\nIf the player is not currently in a screen or the screen has no slots, returns nil",
+  "figura.docs.host.get_screen_slot": "Gets the item in a screen slot\nIf the player is not currently in a screen, the screen has no slots, or the slot index is greater than the maximum (host:getScreenSlotCount()), returns nil",
   "figura.docs.host.is_chat_open": "Checks if the host has the chat screen opened",
   "figura.docs.host.is_container_open": "Checks if the host has a container screen opened",
   "figura.docs.host.screenshot": "Takes a screenshot from the current screen and returns a Texture of it",


### PR DESCRIPTION
Adds two methods:
* `host:getScreenSlotCount()`
  Gets the number of slots in the screen the player is currently in.
  If the player is not currently in a screen or the screen has no slots, returns nil.
* `host:getScreenSlot(index)`
  Gets the item in a screen slot.
  If the player is not currently in a screen, the screen has no slots, or the slot index is greater than the maximum (host:getScreenSlotCount()), returns nil.

I have tested both of these methods. You can use [this avatar](https://github.com/Kingdom-of-The-Moon/FiguraRewriteRewrite/files/11829618/avatar.zip) to test: the first value will be the total number of slots in the current screen or nil if no screen is open, and the second value will be the first slot's contents. You can test by getting an item and a chest, then putting the item in the first slot of the chest.